### PR TITLE
a11y updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,15 @@
 <!DOCTYPE html>
-<html lang="us-en">
+<html lang="en-us" class="no-js">
   <head>
     <meta charset="utf-8">
     <title>Starry Open Source</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <script>
+      document.documentElement.className = document.documentElement.className.replace('no-js', " ");
+      document.documentElement.className += ' js ';
+    </script>
+
     <meta name="description" content="Starry Open Source" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <meta property="og:url" content="http://starryinternet.github.io" />
     <meta property="og:type" content="website" />
@@ -16,6 +21,7 @@
 
     <link href="src/css/font-awesome.min.css" rel="stylesheet">
     <link href="src/css/style.css" rel="stylesheet">
+
     <link href="https://dyajmw2sca9cs.cloudfront.net/img/favicon16.png" rel="icon" type="image/png" sizes="16x16">
     <link href="https://dyajmw2sca9cs.cloudfront.net/img/favicon32.png" rel="icon" type="image/png" sizes="32x32">
 
@@ -36,19 +42,23 @@
 
       <section class="hero">
         <canvas id="foreground" class="canvas foreground"></canvas>
-        <svg>
-          <symbol id="s-text">
-            <text text-anchor="middle" x="50%" y="50%" class="text--line">Open Source</text>
-          </symbol>
-          <g class="g-ants">
-            <use xlink:href="#s-text" class="text-copy"></use>
-            <use xlink:href="#s-text" class="text-copy"></use>
-            <use xlink:href="#s-text" class="text-copy"></use>
-            <use xlink:href="#s-text" class="text-copy"></use>
-            <use xlink:href="#s-text" class="text-copy"></use>
-          </g>
-        </svg>
-      </section>
+          <h1 class="sr-only heading-fallback">
+            Open Source
+          </h1>
+          <svg role="img" aria-label="Animated Open Source title" class="open-source-svg">
+            <title id="svg_title">Open Source</title>
+            <symbol id="s-text">
+              <text text-anchor="middle" x="50%" y="50%" class="text--line">Open Source</text>
+            </symbol>
+            <g class="g-ants">
+              <use xlink:href="#s-text" class="text-copy"></use>
+              <use xlink:href="#s-text" class="text-copy"></use>
+              <use xlink:href="#s-text" class="text-copy"></use>
+              <use xlink:href="#s-text" class="text-copy"></use>
+              <use xlink:href="#s-text" class="text-copy"></use>
+            </g>
+          </svg>
+      </header>
 
       <section class="text-panel">
         <div class="load-transition">

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
       <section class="text-panel">
         <div class="load-transition">
           <h2>Starry loves Open Source</h2>
-          <p>We use open source software every day to build incredible things at Starry, so it only seemed fair to contribute some of our own.</p>
+          <p class="txt-h3">We use open source software every day to build incredible things at Starry, so it only seemed fair to contribute some of our own.</p>
         </div>
       </section>
 
@@ -88,7 +88,7 @@
                   missive
                 </h3>
                 <p>Fast, lightweight library for sending JSON over streams.</p>
-                <a class="project-link" href="https://github.com/StarryInternet/missive"><span aria-hidden="true" class="fa fa-github"></span> 
+                <a class="project-link" href="https://github.com/StarryInternet/missive"><span aria-hidden="true" class="fa fa-github"></span>
                 View <span class="sr-only">missive</span> Project</a>
               </div>
             </article>
@@ -100,7 +100,7 @@
                   map-memo
                 </h3>
                 <p>Generic JavaScript memoization with Map and WeakMap.</p>
-                <a class="project-link" href="https://github.com/StarryInternet/map-memo"><span aria-hidden="true" class="fa fa-github"></span> 
+                <a class="project-link" href="https://github.com/StarryInternet/map-memo"><span aria-hidden="true" class="fa fa-github"></span>
                 View <span class="sr-only">map-memo</span> Project</a>
               </div>
             </article>
@@ -112,7 +112,7 @@
                   eslint-config-starry
                 </h3>
                 <p>Our ESLint config. IdiomaticJS, plus some ES6 conventions.</p>
-                <a class="project-link" href="https://github.com/StarryInternet/eslint-config-starry"><span aria-hidden="true" class="fa fa-github"></span> 
+                <a class="project-link" href="https://github.com/StarryInternet/eslint-config-starry"><span aria-hidden="true" class="fa fa-github"></span>
                 View <span class="sr-only">eslint-config-starry</span> Project</a>
               </div>
             </article>
@@ -124,7 +124,7 @@
                   eslint-plugin-starry
                 </h3>
                 <p>A few custom ESLint rules for Idiomatic whitespace.</p>
-                <a class="project-link" href="https://github.com/StarryInternet/eslint-plugin-starry"><span aria-hidden="true" class="fa fa-github"></span> 
+                <a class="project-link" href="https://github.com/StarryInternet/eslint-plugin-starry"><span aria-hidden="true" class="fa fa-github"></span>
                 View <span class="sr-only">eslint-plugin-starry</span> Project</a>
               </div>
             </article>

--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
           <p class="copyright">
             &copy; 2016 Starry, Inc.
             <br>
-            <span class="emoji" role="presentation">🤖 🤖 🤖 🤖 🤖</span>
+            <span class="emoji">🤖 🤖 🤖 🤖 🤖</span>
           </p>
 
         </div>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="us-en">
   <head>
     <meta charset="utf-8">
     <title>Starry Open Source</title>
@@ -14,10 +14,9 @@
     <meta property="og:image" content="http://dyajmw2sca9cs.cloudfront.net/oss/og-image.png" />
     <meta property="og:image:secure_url" content="https://dyajmw2sca9cs.cloudfront.net/oss/og-image.png" />
 
-    <link rel="stylesheet" href="src/css/font-awesome.min.css">
-    <link rel="stylesheet" href="src/css/style.css">
-    <link rel="icon" href="https://dyajmw2sca9cs.cloudfront.net/img/favicon16.png" type="image/png" sizes="16x16">
-    <link rel="icon" href="https://dyajmw2sca9cs.cloudfront.net/img/favicon32.png" type="image/png" sizes="32x32">
+    <link href="src/css/font-awesome.min.css" rel="stylesheet">
+    <link href="src/css/style.css" rel="stylesheet">
+    <link href="https://dyajmw2sca9cs.cloudfront.net/img/favicon16.png" rel="icon" type="image/png" sizes="16x16">
 
     <!-- I know, I know. But I actually *want* these to block rendering -->
     <script src="src/js/triangle.js"></script>

--- a/index.html
+++ b/index.html
@@ -31,16 +31,25 @@
   </head>
   <body>
 
-    <header>
-      <nav class="load-transition">
-        <a href="https://starry.com" class="logo"></a>
-        <a href="https://github.com/StarryInternet" class="github"><i class="fa fa-github fa-2x" ></i></a>
+    <header role="banner">
+      <nav class="load-transition" role="navigation" aria-label="Main">
+        <a href="https://starry.com" class="logo">
+          <span class="sr-only">
+            Starry: visit Starry.com
+          </span>
+        </a>
+        <a href="https://github.com/StarryInternet" class="github">
+          <span class="fa fa-github fa-2x" aria-hidden="true"></span>
+          <span class="sr-only">
+            Starry on GitHub
+          </span>
+        </a>
       </nav>
     </header>
 
-    <main>
+    <main role="main" aria-label="Content">
 
-      <section class="hero">
+      <header class="hero">
         <canvas id="foreground" class="canvas foreground"></canvas>
           <h1 class="sr-only heading-fallback">
             Open Source
@@ -63,7 +72,7 @@
       <section class="text-panel">
         <div class="load-transition">
           <h2>Starry loves Open Source</h2>
-          <h3>We use open source software every day to build incredible things at Starry, so it only seemed fair to contribute some of our own.</h3>
+          <p>We use open source software every day to build incredible things at Starry, so it only seemed fair to contribute some of our own.</p>
         </div>
       </section>
 
@@ -72,37 +81,53 @@
 
           <h2 class="body-h2">Our Projects</h2>
 
-          <article class="project">
-            <div>
-              <h2><span class="lang">.js</span>missive</h2>
-              <p>Fast, lightweight library for sending JSON over streams.</p>
-              <a class="project-link" href="https://github.com/StarryInternet/missive"><i class="fa fa-github"></i> View Project</i></a>
-            </div>
-          </article>
+            <article class="project">
+              <div>
+                <h3>
+                  <span class="lang" aria-hidden="true">.js</span>
+                  missive
+                </h3>
+                <p>Fast, lightweight library for sending JSON over streams.</p>
+                <a class="project-link" href="https://github.com/StarryInternet/missive"><span aria-hidden="true" class="fa fa-github"></span> 
+                View <span class="sr-only">missive</span> Project</a>
+              </div>
+            </article>
 
-          <article class="project">
-            <div>
-              <h2><span class="lang">.js</span>map-memo</h2>
-              <p>Generic JavaScript memoization with Map and WeakMap.</p>
-              <a class="project-link" href="https://github.com/StarryInternet/map-memo"><i class="fa fa-github"></i> View Project</i></a>
-            </div>
-          </article>
+            <article class="project">
+              <div>
+                <h3>
+                  <span class="lang" aria-hidden="true">.js</span>
+                  map-memo
+                </h3>
+                <p>Generic JavaScript memoization with Map and WeakMap.</p>
+                <a class="project-link" href="https://github.com/StarryInternet/map-memo"><span aria-hidden="true" class="fa fa-github"></span> 
+                View <span class="sr-only">map-memo</span> Project</a>
+              </div>
+            </article>
 
-          <article class="project">
-            <div>
-              <h2><span class="lang">.js</span>eslint-config-starry</h2>
-              <p>Our ESLint config. IdiomaticJS, plus some ES6 conventions.</p>
-              <a class="project-link" href="https://github.com/StarryInternet/eslint-config-starry"><i class="fa fa-github"></i> View Project</a>
-            </div>
-          </article>
+            <article class="project">
+              <div>
+                <h3>
+                  <span class="lang" aria-hidden="true">.js</span>
+                  eslint-config-starry
+                </h3>
+                <p>Our ESLint config. IdiomaticJS, plus some ES6 conventions.</p>
+                <a class="project-link" href="https://github.com/StarryInternet/eslint-config-starry"><span aria-hidden="true" class="fa fa-github"></span> 
+                View <span class="sr-only">eslint-config-starry</span> Project</a>
+              </div>
+            </article>
 
-          <article class="project">
-            <div>
-              <h2><span class="lang">.js</span>eslint-plugin-starry</h2>
-              <p>A few custom ESLint rules for Idiomatic whitespace.</p>
-              <a class="project-link" href="https://github.com/StarryInternet/eslint-plugin-starry"><i class="fa fa-github"></i> View Project</a>
-            </div>
-          </article>
+            <article class="project">
+              <div>
+                <h3>
+                  <span class="lang" aria-hidden="true">.js</span>
+                  eslint-plugin-starry
+                </h3>
+                <p>A few custom ESLint rules for Idiomatic whitespace.</p>
+                <a class="project-link" href="https://github.com/StarryInternet/eslint-plugin-starry"><span aria-hidden="true" class="fa fa-github"></span> 
+                View <span class="sr-only">eslint-plugin-starry</span> Project</a>
+              </div>
+            </article>
 
         </div>
       </section>
@@ -111,15 +136,17 @@
         <div class="load-transition">
           <h2>Work at Starry</h2>
 
-          <h3>We love coming up with huge ideas and figuring out ways to bring them to life. Our team spans RF engineering, hardware architecture, firmware, UX, UI, software, industrial design, marketing, branding, and communications. And one thing we all share is an intense desire to make something beautiful. Something that makes a real dent.</h3>
+          <p class="txt-h3">We love coming up with huge ideas and figuring out ways to bring them to life. Our team spans RF engineering, hardware architecture, firmware, UX, UI, software, industrial design, marketing, branding, and communications. And one thing we all share is an intense desire to make something beautiful. Something that makes a real dent.</p>
 
-          <p><a href="https://starry.com/careers">View open positions</a></p>
+          <p>
+            <a href="https://starry.com/careers">View open positions <span class="sr-only">at Starry</span></a>
+          </p>
 
 
           <p class="copyright">
-            © 2016 Starry, Inc.
+            &copy; 2016 Starry, Inc.
             <br>
-            <span class="emoji">🤖 🤖 🤖 🤖 🤖</span>
+            <span class="emoji" role="presentation">🤖 🤖 🤖 🤖 🤖</span>
           </p>
 
         </div>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <link href="src/css/font-awesome.min.css" rel="stylesheet">
     <link href="src/css/style.css" rel="stylesheet">
     <link href="https://dyajmw2sca9cs.cloudfront.net/img/favicon16.png" rel="icon" type="image/png" sizes="16x16">
+    <link href="https://dyajmw2sca9cs.cloudfront.net/img/favicon32.png" rel="icon" type="image/png" sizes="32x32">
 
     <!-- I know, I know. But I actually *want* these to block rendering -->
     <script src="src/js/triangle.js"></script>

--- a/index.html
+++ b/index.html
@@ -115,7 +115,6 @@
 
           <p><a href="https://starry.com/careers">View open positions</a></p>
 
-          <br><br><br><br>
 
           <p class="copyright">
             © 2016 Starry, Inc.

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -46,6 +46,16 @@ a {
           transition: color 0.3s;
 }
 
+.sr-only {
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  opacity: 0;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  pointer-events: none;
+}
+
 .emoji {
   font-family:"Apple Color Emoji","Segoe UI Emoji","NotoColorEmoji","Segoe UI Symbol","Android Emoji","EmojiSymbols";
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -31,6 +31,7 @@ html, body {
   color: #131c4e;
   font-size: 18px;
   font-weight: 300;
+  overflow-x: hidden;
 }
 
 body {
@@ -68,7 +69,7 @@ p, h3 {
   line-height: 1.7em;
 }
 
-.load-transition {
+.js .load-transition {
   opacity: 0;
   -webkit-transform: translateY( 8px );
           transform: translateY( 8px );
@@ -78,7 +79,7 @@ p, h3 {
           transition-delay: 0.25s;
 }
 
-body.active .load-transition {
+.js body.active .load-transition {
   opacity: 1;
   -webkit-transform: translateY( 0px );
           transform: translateY( 0px );
@@ -370,5 +371,39 @@ body.active .text-copy:nth-child( 5 ) {
   }
   .text--line {
     font-size: 46px;
+  }
+}
+
+
+/* no-js fallbacks */
+.no-js .open-source-svg {
+  display: none;
+}
+
+.no-js .sr-only.heading-fallback {
+  clip: inherit;
+  color: #fff;
+  font-size: 46px;
+  height: auto;
+  left: 0;
+  opacity: 1;
+  overflow: visible;
+  right: 0;
+  text-align: center;
+  top: 40%;
+  width: auto;
+}
+
+@media screen and ( min-width: 581px )  {
+  .no-js .sr-only.heading-fallback {
+    font-size: 64px;
+    top: 46%;
+  }
+}
+
+@media screen and ( min-width: 780px ) {
+  .no-js .sr-only.heading-fallback {
+    font-size: 84px;
+    top: 48%;
   }
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -309,6 +309,7 @@ body.active .text-copy:nth-child( 5 ) {
 .copyright {
   font-size: 16px;
   line-height: 32px;
+  margin-top: 122px;
 }
 
 @media only screen and ( max-width: 780px )  {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -61,12 +61,17 @@ a {
   font-family:"Apple Color Emoji","Segoe UI Emoji","NotoColorEmoji","Segoe UI Symbol","Android Emoji","EmojiSymbols";
 }
 
-a:hover {
+a:hover,
+a:focus {
   color: #131c4e;
 }
 
 p, h3 {
   line-height: 1.7em;
+}
+
+.txt-h3 {
+  font-size: 21px;
 }
 
 .js .load-transition {
@@ -85,7 +90,7 @@ p, h3 {
           transform: translateY( 0px );
 }
 
-header {
+header[role="banner"] {
   background: rgba( 255, 255, 255, 0.9 );
   width: 100%;
   height: 80px;
@@ -288,7 +293,8 @@ body.active .text-copy:nth-child( 5 ) {
   box-shadow: 0 0 8px rgba( 60,77 ,119, 0.25 );
 }
 
-.project h2 {
+.project h3 {
+  font-size: 27px;
   margin: 0;
 }
 


### PR DESCRIPTION
the following PR includes:
- markup updates to be more inline with expected document semantics  
- updated styles to retain previous styling with the new appropriate elements swapped in  
- no-js fallback to ensure content can be viewable without JavaScript  
- various instances of screen reader only content added, and updates to correct / remove some instances of content that was not being reported by ATs in a suitable manner.

see individual commits for more detail.
